### PR TITLE
Added support for dest argument in options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ gulp.task('default', function () {
 
 ## API
 
-### livingcss([options])
+### livingcss([options], [dest])
 
 #### options
 
 See the LivingCSS [options](https://github.com/straker/livingcss#options).
+
+#### dest
+
+See the LivingCSS [dest](https://github.com/straker/livingcss#usage).

--- a/index.js
+++ b/index.js
@@ -9,9 +9,11 @@ var minify = require('html-minifier').minify;
 /**
  * Buffer all files before passing the file list to livingcss.
  * @param {object} [options] - Options to pass to livingcss.
+ * @param {string} [dest] - Destination path to pass to livingcss.
  */
-module.exports = function (options) {
+module.exports = function (options, dest) {
   options = options || {};
+  dest = dest || '';
 
   // list of all files from gulp.src
   var files = [];
@@ -47,6 +49,8 @@ module.exports = function (options) {
     // through that step of the generate script
     var preprocessFunc = options.preprocess;
     options.preprocess = function(context, template, Handlebars) {
+
+      var dest = '';
 
       // if no preprocess function then resolve a promise
       var preprocess = (preprocessFunc ?
@@ -88,7 +92,7 @@ module.exports = function (options) {
       return false;
     }
 
-    livingcss(files, '', options);
+    livingcss(files, dest, options);
   }
 
   return through.obj(bufferContents, endStream);


### PR DESCRIPTION
Hey there,

I was playing around with this library a little bit and missed the `dest` argument of `livingcss`. After taking a look at your code, I saw that the argument will always be an empty string.

To support the argument I added the `dest` property to the `options` object which will be deleted automatically before the `options` object is forwarded to `livingcss`.

I would be glad if you merge this little piece of code to the next version of `gulp-livingcss`.

Thanks and kind regards,
Dominic
