### PR TITLE
Add option to clean css before template compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var through = require('through2');
+var CleanCSS = require('clean-css');
 var path = require('path');
 var File = require('vinyl') ;
 var PluginError = require('plugin-error');
@@ -84,6 +85,19 @@ module.exports = function (dest, options) {
           });
         })
         .then(function success() {
+          // if we want to clean the css with clean-css
+          // We can pass options through if needed
+          // This will make sure that the size of the included styles are low
+          if(options.cleanCSS){
+            var allCSS = context.parsedStylesheets
+              .map(function(stylesheet) {
+                return stylesheet;
+              })
+              .join('\n');
+            var allDedupedCSS =  new CleanCSS({ level: 2 })
+              .minify(allCSS)
+              context.parsedStylesheets = [allDedupedCSS.styles];;
+          }
           var html = Handlebars.compile(template)(context);
 
           if (options.minify) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through = require('through2');
-var CleanCSS = require('clean-css');
+
 var path = require('path');
 var File = require('vinyl') ;
 var PluginError = require('plugin-error');
@@ -85,30 +85,13 @@ module.exports = function (dest, options) {
           });
         })
         .then(function success() {
-          // if we want to clean the css with clean-css
-          // We can pass options through if needed
-          // This will make sure that the size of the included styles are low
-          if(options.cleanCSS){
-            var allCSS = context.parsedStylesheets
-              .map(function(stylesheet) {
-                return stylesheet;
-              })
-              .join('\n');
-            var allDedupedCSS =  new CleanCSS({
-              level: {
-                2: {
-                  all: false, // sets all values to `false`
-                  removeDuplicateRules: true // turns on removing duplicate rules
-                }
-              }})
-              .minify(allCSS)
-              context.parsedStylesheets = [allDedupedCSS.styles];;
-          }
+
           var html = Handlebars.compile(template)(context);
 
           if (options.minify) {
             html = minify(html, {
-              collapseWhitespace: true
+              collapseWhitespace: true,
+              minifyCSS: options.minifyCSS || false
             });
           }
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,13 @@ module.exports = function (dest, options) {
                 return stylesheet;
               })
               .join('\n');
-            var allDedupedCSS =  new CleanCSS({ level: 2 })
+            var allDedupedCSS =  new CleanCSS({
+              level: {
+                2: {
+                  all: false, // sets all values to `false`
+                  removeDuplicateRules: true // turns on removing duplicate rules
+                }
+              }})
               .minify(allCSS)
               context.parsedStylesheets = [allDedupedCSS.styles];;
           }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/straker/gulp-livingcss",
   "dependencies": {
-    "clean-css": "^4.2.1",
     "html-minifier": "^4.0.0",
     "livingcss": "^6.0.0",
     "normalize-newline": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/straker/gulp-livingcss",
   "dependencies": {
+    "clean-css": "^4.2.1",
     "html-minifier": "^4.0.0",
     "livingcss": "^6.0.0",
     "normalize-newline": "^3.0.0",


### PR DESCRIPTION
Greatly reduces size of styles (I shaved over 3 megabytes per page in my use case) :)

This uses clean-css to remove dupes. But sadly, it is a bit slow, and has to be run for every page you make. For my sake, it's doing the same job 4 times, with the same css, since I have 4 pages. But the gains outweighs the pain here, for now

(This is a new PR, the old one (#21 ) was based on an old version of gulp-livingcss)